### PR TITLE
fix: Consistent syntax for GHA variables

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -48,7 +48,7 @@ jobs:
         # Ask me how I know!
         if [ -n ${{ env.PACKAGE_PATH }} ]; then
           echo "Cleaning ${{ env.PACKAGE_PATH }}/*"
-          ls '${{ env.PACKAGE_PATH }}'
+          ls '${{ env.PACKAGE_PATH }}' || true
         else
           echo "PACKAGE_PATH not set"
         fi

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -18,7 +18,7 @@ env:
   BUILD_VERSION: ${{ inputs.build-version && inputs.build-version || '0.0.0-ci.0' }}
   BUILD_CONFIG: ${{ inputs.configuration && inputs.configuration || 'Release'}}
   SOLUTION: 'NuGetWorkflow.sln'
-  NuGetDirectory: ${{ inputs.output-folder && inputs.output-folder || format('{0}/publish', github.workspace) }}
+  PACKAGE_PATH: ${{ inputs.output-folder && inputs.output-folder || format('{0}/publish', github.workspace) }}
 
 jobs:
   build:
@@ -38,8 +38,8 @@ jobs:
 
     - name: Clean output directory
       run: |
-        echo $NuGetDirectory/*
-        rm -rf $NuGetDirectory/*
+        echo 'Cleaning ${{ env.PACKAGE_PATH }}/'
+        rm -rf ${{ env.PACKAGE_PATH }}/*
 
     - name: Build
       run: >-
@@ -64,7 +64,7 @@ jobs:
         --no-build
         --verbosity normal
         -p:Version=$BUILD_VERSION
-        --output $NuGetDirectory
+        --output ${{ env.PACKAGE_PATH }}
 
     # Validate metadata and content of the NuGet package
     # https://www.nuget.org/packages/Meziantou.Framework.NuGetPackageValidation.Tool#readme-body-tab
@@ -72,7 +72,7 @@ jobs:
     # using the --excluded-rules or --excluded-rule-ids option
     - name: Validate package
       run: >-
-        ls $NuGetDirectory/*.nupkg | xargs dotnet tool run meziantou.validate-nuget-package
+        ls ${{ env.PACKAGE_PATH }}/*.nupkg | xargs dotnet tool run meziantou.validate-nuget-package
 
     - name: Upload nupkg artifact
       uses: actions/upload-artifact@v3
@@ -80,4 +80,4 @@ jobs:
         name: nupkg
         if-no-files-found: error
         retention-days: 7
-        path: '${{ env.NuGetDirectory }}/*.nupkg'
+        path: '${{ env.PACKAGE_PATH }}/*.nupkg'

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -37,7 +37,9 @@ jobs:
         dotnet tool restore
 
     - name: Clean output directory
-      run: rm -rf ${NuGetDirectory}/*
+      run: |
+        echo $NuGetDirectory/*
+        rm -rf $NuGetDirectory/*
 
     - name: Build
       run: >-
@@ -62,7 +64,7 @@ jobs:
         --no-build
         --verbosity normal
         -p:Version=$BUILD_VERSION
-        --output ${NuGetDirectory}
+        --output $NuGetDirectory
 
     # Validate metadata and content of the NuGet package
     # https://www.nuget.org/packages/Meziantou.Framework.NuGetPackageValidation.Tool#readme-body-tab
@@ -70,7 +72,7 @@ jobs:
     # using the --excluded-rules or --excluded-rule-ids option
     - name: Validate package
       run: >-
-        ls ${NuGetDirectory}/*.nupkg | xargs dotnet tool run meziantou.validate-nuget-package
+        ls $NuGetDirectory/*.nupkg | xargs dotnet tool run meziantou.validate-nuget-package
 
     - name: Upload nupkg artifact
       uses: actions/upload-artifact@v3
@@ -78,4 +80,4 @@ jobs:
         name: nupkg
         if-no-files-found: error
         retention-days: 7
-        path: ${{ env.NuGetDirectory }}/*.nupkg
+        path: $NuGetDirectory/*.nupkg

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -40,14 +40,8 @@ jobs:
 
     - name: Clean output directory
       run: |
-        # Defensive coding so we don't rm -rf /* if PACKAGE_PATH is unset
-        # Ask me how I know!
-        if [ -n ${{ env.PACKAGE_PATH }} ]; then
-          echo "Cleaning ${{ env.PACKAGE_PATH }}/*"
-          ls '${{ env.PACKAGE_PATH }}' || true
-        else
-          echo "PACKAGE_PATH not set"
-        fi
+        echo "Cleaning ${{ env.PACKAGE_PATH }}"
+        [ -d ${{ env.PACKAGE_PATH }} ] && rm -rf ${{ env.PACKAGE_PATH }}
 
     - name: Build
       run: >-

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -80,4 +80,4 @@ jobs:
         name: nupkg
         if-no-files-found: error
         retention-days: 7
-        path: $NuGetDirectory/*.nupkg
+        path: '${{ env.NuGetDirectory }}/*.nupkg'

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -32,16 +32,10 @@ jobs:
         dotnet restore $SOLUTION
         dotnet tool restore
 
-    - name: Diagnostics
-      run: |
-        echo 'PACKAGE_PATH=${{ env.PACKAGE_PATH }}/'
-        echo 'PACKAGE_PATH=${PACKAGE_PATH}/'
-        echo 'PACKAGE_PATH=$PACKAGE_PATH/'
-
     - name: Clean output directory
       run: |
         echo "Cleaning ${{ env.PACKAGE_PATH }}"
-        [ -d ${{ env.PACKAGE_PATH }} ] && rm -rf ${{ env.PACKAGE_PATH }}
+        [ -d ${{ env.PACKAGE_PATH }} ] && rm -rf ${{ env.PACKAGE_PATH }} || true
 
     - name: Build
       run: >-

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -36,10 +36,15 @@ jobs:
         dotnet restore $SOLUTION
         dotnet tool restore
 
+    - name: Diagnostics
+      run: |
+        echo 'PACKAGE_PATH=${{ env.PACKAGE_PATH }}/'
+        echo 'PACKAGE_PATH=${PACKAGE_PATH}/'
+        echo 'PACKAGE_PATH=$PACKAGE_PATH/'
+
     - name: Clean output directory
       run: |
-        echo 'Cleaning ${{ env.PACKAGE_PATH }}/'
-        rm -rf ${{ env.PACKAGE_PATH }}/*
+        [[ -z "${{ env.PACKAGE_PATH }}" ]] && echo "PACKAGE_PATH not set" || rm -rf ${{ env.PACKAGE_PATH }}/*
 
     - name: Build
       run: >-

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -44,7 +44,7 @@ jobs:
 
     - name: Clean output directory
       run: |
-        [[ -z "${{ env.PACKAGE_PATH }}" ]] && echo "PACKAGE_PATH not set" || rm -rf ${{ env.PACKAGE_PATH }}/*
+        [ -n ${{ env.PACKAGE_PATH }} ] && ls ${{ env.PACKAGE_PATH }}/* || echo "PACKAGE_PATH not set"
 
     - name: Build
       run: >-

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -44,7 +44,14 @@ jobs:
 
     - name: Clean output directory
       run: |
-        [ -n ${{ env.PACKAGE_PATH }} ] && ls ${{ env.PACKAGE_PATH }}/* || echo "PACKAGE_PATH not set"
+        # Defensive coding so we don't rm -rf /* if PACKAGE_PATH is unset
+        # Ask me how I know!
+        if [ -n ${{ env.PACKAGE_PATH }} ]; then
+          echo "Cleaning ${{ env.PACKAGE_PATH }}/*"
+          ls '${{ env.PACKAGE_PATH }}'
+        else
+          echo "PACKAGE_PATH not set"
+        fi
 
     - name: Build
       run: >-

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -8,17 +8,13 @@ on:
         required: false
         type: string
         default: 'Release'
-      output-folder:
-        required: false
-        type: string
-        default: ${{ github.workspace }}/publish
   workflow_dispatch:    # Allow running the workflow manually from the GitHub UI
 
 env:
   BUILD_VERSION: ${{ inputs.build-version && inputs.build-version || '0.0.0-ci.0' }}
   BUILD_CONFIG: ${{ inputs.configuration && inputs.configuration || 'Release'}}
   SOLUTION: 'NuGetWorkflow.sln'
-  PACKAGE_PATH: ${{ inputs.output-folder && inputs.output-folder || format('{0}/publish', github.workspace) }}
+  PACKAGE_PATH: ${{ github.workspace }}/publish
 
 jobs:
   build:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,7 @@ jobs:
     uses: ./.github/workflows/build-and-test.yml
     with:
       build-version: ${{ needs.init.outputs.build-version }}
-      output-folder: ${{ env.PACKAGE_PATH }}
+      output-folder: ${PACKAGE_PATH}
 
   diag:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,6 @@ on:
 env:
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
   DOTNET_NOLOGO: true
-  PACKAGE_PATH: ${{ github.workspace}}/nuget
 
 jobs:
   init:
@@ -29,7 +28,7 @@ jobs:
       uses: madhead/semver-utils@latest
       id: semver_parser
       with:
-        # A version to work with
+        # Parse the latest release version, or a default value if nothing is released
         version: >
           ${{ steps.get_current_version.outputs.release-version != '[unreleased]'
             && steps.get_current_version.outputs.release-version
@@ -50,11 +49,12 @@ jobs:
     uses: ./.github/workflows/build-and-test.yml
     with:
       build-version: ${{ needs.init.outputs.build-version }}
-      output-folder: ${PACKAGE_PATH}
 
   diag:
     runs-on: ubuntu-latest
     needs: build
+    env:
+      PACKAGE_PATH: ${{ github.workspace }}/nuget
     steps:
     - name: Download nupkg artifact
       uses: actions/download-artifact@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
 env:
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
   DOTNET_NOLOGO: true
-  NuGetDirectory: ${{ github.workspace}}/nuget
+  PACKAGE_PATH: ${{ github.workspace}}/nuget
 
 jobs:
   init:
@@ -50,7 +50,7 @@ jobs:
     uses: ./.github/workflows/build-and-test.yml
     with:
       build-version: ${{ needs.init.outputs.build-version }}
-      output-folder: $NuGetDirectory
+      output-folder: ${{ env.PACKAGE_PATH }}
 
   diag:
     runs-on: ubuntu-latest
@@ -60,8 +60,8 @@ jobs:
       uses: actions/download-artifact@v3
       with:
         name: nupkg
-        path: ${{ env.NuGetDirectory }}
+        path: ${{ env.PACKAGE_PATH }}
 
     - name: Diagnostics
       run: |
-        ls ${{ env.NuGetDirectory }}
+        ls ${{ env.PACKAGE_PATH }}


### PR DESCRIPTION
The syntax for the GHA variables was inconsistent, and it was resolving to an incorrect package output path. This PR makes the syntax internally consistent and according to the [documentation](https://docs.github.com/en/actions/learn-github-actions/environment-variables). The package output path variable was renamed to `PACKAGE_PATH` to accord with the [naming conventions](https://docs.github.com/en/actions/learn-github-actions/environment-variables#naming-conventions-for-environment-variables).

Fixes #7 