### PR TITLE
feat: Add repo label management

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -1,0 +1,79 @@
+- name: 'good first issue'
+  color: '5319e7'
+  description: 'Good for newcomers'
+  aliases: []
+
+- name: 'help wanted'
+  color: '008672'
+  description: 'Extra attention is needed'
+  aliases: []
+
+- name: 'status: pending'
+  color: c5def5
+  description: 'More info is needed before deciding what to do'
+  aliases: []
+
+- name: 'status: pinned'
+  color: 0052cc
+  description: 'Should not be labeled as stale'
+  aliases: []
+
+- name: 'status: stale'
+  color: fbca04
+  description: 'Inactive issues and PRs'
+  aliases: ['stale']
+
+- name: 'status: wontfix'
+  color: cfd3d7
+  description: 'This will not be worked on'
+  aliases: ['wontfix']
+
+- name: 'type: bug'
+  color: d73a4a
+  description: 'Verified problems that need to be worked on'
+  aliases: ['bug']
+
+- name: 'type: chore'
+  color: C5DEF5
+  description: 'Code changes that neither fix bugs nor add features (refactoring, dependency changes, ...)'
+  aliases: ['dependencies', 'type: dependencies', 'automation', 'type: automation']
+
+- name: 'type: docs'
+  color: C5DEF5
+  description: "Documentation changes"
+  aliases: ['documentation', 'maintenance', 'type: maintenance']
+
+- name: 'type: duplicate'
+  color: cfd3d7
+  description: 'This issue or pull request already exists'
+  aliases: ['duplicate']
+
+- name: 'type: feature'
+  color: 0E8A16
+  description: 'New feature or feature request'
+  aliases: ['enhancement', 'type: enhancement']
+
+- name: 'type: fix'
+  color: 1D76DB
+  description: 'Updates to existing functionalities'
+  aliases: ['fix']
+
+- name: 'type: invalid'
+  color: e4e669
+  description: "This doesn't seem right"
+  aliases: ['invalid']
+
+- name: 'type: not a bug'
+  color: 0e8a16
+  description: 'Reports that happen not be our fault'
+  aliases: ['not a bug']
+
+- name: 'type: question'
+  color: d876e3
+  description: 'Further information is requested'
+  aliases: ['question']
+
+- name: 'autorelease'
+  color: baa938
+  description: 'PRs that are part of the automated release process'
+  aliases: []

--- a/.github/workflows/sync-labels.yml
+++ b/.github/workflows/sync-labels.yml
@@ -1,0 +1,24 @@
+# Keeps the repo labels in sync with .github/labels.yml
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - .github/labels.yml
+  workflow_dispatch:  # Allow running the workflow manually from the GitHub UI
+
+
+jobs:
+  sync:
+    name: Run
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@1.0.0
+      - uses: EndBug/label-sync@v2
+        with:
+          config-file: .github/labels.yml
+          delete-other-labels: false
+          dry-run: true
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/sync-labels.yml
+++ b/.github/workflows/sync-labels.yml
@@ -19,6 +19,6 @@ jobs:
       - uses: EndBug/label-sync@v2
         with:
           config-file: .github/labels.yml
-          delete-other-labels: false
+          delete-other-labels: true
           dry-run: true
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Adds declarative management of repo labels by using `.github/labels/yml` and the `sync-labels.yml` workflow.