### PR TITLE
feat: Labels part2

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -64,7 +64,7 @@
   aliases: ['invalid']
 
 - name: 'type: not a bug'
-  color: 0e8a16
+  color: e4e669
   description: 'Reports that happen not be our fault'
   aliases: ['not a bug']
 

--- a/.github/workflows/sync-labels.yml
+++ b/.github/workflows/sync-labels.yml
@@ -1,5 +1,7 @@
 # Keeps the repo labels in sync with .github/labels.yml
 
+name: Sync labels
+
 on:
   push:
     branches:
@@ -11,14 +13,15 @@ on:
 
 jobs:
   sync:
-    name: Run
+    name: Perform sync
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@1.0.0
+        uses: actions/checkout@v3
+
       - uses: EndBug/label-sync@v2
         with:
           config-file: .github/labels.yml
           delete-other-labels: true
-          dry-run: true
+          dry-run: false
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
The first PR created the workflow but left it in dry run mode. This PR switches it on.