### PR TITLE
fix: Provide prerelease identifier in workflow

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -24,6 +24,7 @@ jobs:
   changelog:
     name: Update changelog and create PR
     runs-on: ubuntu-latest
+
     steps:
     - uses: actions/checkout@v3
       with:
@@ -54,6 +55,7 @@ jobs:
       uses: release-flow/keep-a-changelog-action/prepare-release@v1
       with:
         release-type: ${{ github.event.inputs.release-type }}
+        prerelease-identifier: ${{ github.event.inputs.prerelease-identifier }}
 
     - name: Create Pull Request
       id: create-release-pr


### PR DESCRIPTION
The prerelease identifier wasn't being passed through to the `release-flow/keep-a-changelog-action/prepare-release` action. This PR addresses that.