### PR TITLE
fix: Update version of release-downloader action

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -15,7 +15,7 @@ on:
         - prerelease
         default: patch
       prerelease-identifier:
-        description: 'Pre-release identifier (only for pre-release builds)'
+        description: 'Pre-release identifier (required for pre-release builds)'
         required: false
 
 name: '[autorelease] Prepare release PR'

--- a/.github/workflows/release-published.yml
+++ b/.github/workflows/release-published.yml
@@ -17,7 +17,7 @@ jobs:
         dotnet-version: 6.0.x
 
     - name: Download nupkg release asset
-      uses: robinraju/release-downloader@v1.6
+      uses: robinraju/release-downloader@63a56bcf84060d864b165ef03efbb696d1a8f066
       with:
         releaseId: '${{ github.event.release.id }}'
         fileName: "*.nupkg"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+
+### Fixed
+
+- Fixed release publishing version bug
+
 ## [0.1.0-alpha.1] - 2022-12-10
 
 ### Added


### PR DESCRIPTION
The current official version of the `release-downloader` action chokes if we use the `releaseId` parameter. A temporary patched version is available, see this [related issue](https://github.com/robinraju/release-downloader/issues/551#issuecomment-1336216007) in the action's repo.

We ought to update to an official release version when one is available. I've subscribed to the related issue.