### PR TITLE
feat: Use package license expression

### DIFF
--- a/src/Yawn/Yawn.csproj
+++ b/src/Yawn/Yawn.csproj
@@ -19,7 +19,7 @@
     <Copyright>Copyright (c) Rich Tebb</Copyright>
     <PackageTags>sample;nuget</PackageTags>
     <PackageReadmeFile>README.md</PackageReadmeFile>
-    <PackageLicenseFile>LICENSE</PackageLicenseFile>
+    <PackageLicenseExpression>ISC</PackageLicenseExpression>
     <PackageProjectUrl></PackageProjectUrl>
     <PackageIcon>icon.png</PackageIcon>
   </PropertyGroup>
@@ -57,7 +57,6 @@
       <Link>StyleCop.json</Link>
     </AdditionalFiles>
     <None Include="..\..\README.md" Pack="true" PackagePath="\" />
-    <None Include="..\..\LICENSE" Pack="true" PackagePath="\" />
     <None Include="..\..\images\icon.png" Pack="true" PackagePath="" />
   </ItemGroup>
 


### PR DESCRIPTION
An SPDX license expression works better than embedding the license text on NuGet.org